### PR TITLE
Wait connection before access to connection attributes

### DIFF
--- a/SpecClient/SpecCommand.py
+++ b/SpecClient/SpecCommand.py
@@ -116,6 +116,8 @@ class BaseSpecCommand:
         if self.connection is None:
             raise SpecClientNotConnectedError
         
+        self.connection.connected_event.wait()
+
         if self.connection.serverVersion < 3:
             func = False
 


### PR DESCRIPTION
Hi,

This patch wait the connection before using it. Else ```serverVersion``` is not defined and is accessed using ```__getattr__``` of the object.

Maybe there is a cleaner way to do it.

Thanks a lot